### PR TITLE
GLEW fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/data)
+set(GLEW_USE_STATIC_LIBS TRUE)
 
 # Use add_resources function to convert .glsl to a .cpp files which will be compiled into a separate static library
 include(add_resources)

--- a/src/gl2_texture/gl2_texture.cpp
+++ b/src/gl2_texture/gl2_texture.cpp
@@ -31,7 +31,7 @@ private:
    * @param width Width of the image to load
    * @param height Height of the image to load
    */
-  void loadImage(const string &image_file, int width, int height) {
+  void loadImage(const std::string &image_file, int width, int height) {
     // Create new OpenGL texture object identifier
     glGenTextures(1, &texture_id);
     glBindTexture(GL_TEXTURE_2D, texture_id);
@@ -44,7 +44,7 @@ private:
     std::ifstream image_stream(image_file, std::ios::binary);
 
     // Setup buffer for pixels (r,g,b bytes), since we will not manipulate the image just keep it as char
-    vector<char> buffer(static_cast<std::size_t>(width * height * 3));
+    std::vector<char> buffer(static_cast<std::size_t>(width * height * 3));
     image_stream.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
     image_stream.close();
 


### PR DESCRIPTION
Added forcing CMake to link projects with GLEW static library not shared as default in Windows.
CMakeLists.txt change according to:
https://cmake.org/cmake/help/v3.15/module/FindGLEW.html

Fix syntax error in GL2_Texture project.